### PR TITLE
Changes to TransactionRow

### DIFF
--- a/app/src/components/TransactionRow.js
+++ b/app/src/components/TransactionRow.js
@@ -36,7 +36,7 @@ const TransactionRow = React.forwardRef(
       event => {
         onUpdate({
           ...transactionItem,
-          amount: parseFloat(event.target.value, 10),
+          amount: event.target.value,
         })
       },
       [onUpdate, transactionItem]


### PR DESCRIPTION
Fixes the bug in which the 0 gets removed in `Transactions`, when entering a value such as 0.1